### PR TITLE
DSOS-2694: Add pipeline to check github workflows

### DIFF
--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   push:
     branches:
-      - **
+      - '*'
 
 jobs:
   get_workflow_runs:

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -18,9 +18,15 @@ jobs:
           - 'dso-infra-azure-ad'
     runs-on: ubuntu-latest
     steps:
-      - name: Setup GitHub API
+      - name: Get Workflow Runs
         id: get_failed_workflow_runs
         run: |
           DATE=$(date -d '1 day ago' '+%Y-%m-%d')   
-          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" 'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE"
+          WORKFLOW_RUNS=`curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" 'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE"`
+          echo "WORKFLOW_RUNS=$WORKFLOW_RUNS" >> $GITHUB_OUTPUT
+      - name: Parse Failed Workflow Runs
+        run:
+          WORKFLOW_FAILS=$("${{ steps.get_failed_workflow_runs.outputs.WORKFLOW_RUNS }}" | jq '.workflow_runs[] | select(.conclusion == "failure") | .id')
+          echo $WORKFLOW_FAILS
+
 

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -22,7 +22,7 @@ jobs:
         id: get_failed_workflow_runs
         run: |
           DATE=$(date -d '1 day ago' '+%Y-%m-%d')   
-          WORKFLOW_RUNS=`curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" 'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE"`
+          WORKFLOW_RUNS=$(curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" 'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE")
           echo "WORKFLOW_RUNS=$WORKFLOW_RUNS" >> $GITHUB_OUTPUT
       - name: Parse Failed Workflow Runs
         run:

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - '*'
+env:
+  AWS_ACCOUNT_ID: ${{ fromJSON(secrets.MODERNISATION_PLATFORM_ENVIRONMENT_MANAGEMENT).account_ids['hmpps-oem-test'] }}
 
 jobs:
   get_workflow_runs:
@@ -18,15 +20,28 @@ jobs:
           - 'dso-infra-azure-ad'
     runs-on: ubuntu-latest
     steps:
+      - name: Setup AWS Credemtials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          role-to-assume: "arn:aws:iam::${{ env.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          aws-region: eu-west-2
       - name: Get Workflow Runs
         id: get_failed_workflow_runs
         run: |
-          DATE=$(date -d '1 day ago' '+%Y-%m-%d')   
-          WORKFLOW_RUNS=$(curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" 'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE")
-          echo "WORKFLOW_RUNS=$WORKFLOW_RUNS" >> $GITHUB_OUTPUT
-      - name: Parse Failed Workflow Runs
-        run:
-          WORKFLOW_FAILS=$("${{ steps.get_failed_workflow_runs.outputs.WORKFLOW_RUNS }}" | jq '.workflow_runs[] | select(.conclusion == "failure") | .id')
-          echo $WORKFLOW_FAILS
-
-
+          DATE=$(date -d '1 day ago' '+%Y-%m-%d')
+          WORKFLOW_RUNS=$(curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" \
+            'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE")
+          FAILED_WORKFLOW_RUNS=$(echo $WORKFLOW_RUNS | jq '[.workflow_runs[] | select(.conclusion == "failure") | .id] | length')
+          if [ $FAILED_WORKFLOW_RUNS -gt 0 ]; then
+            echo "FAILED_WORKFLOW_RUNS=1" >> $GITHUB_OUTPUT
+          else
+            echo "FAILED_WORKFLOW_RUNS=0" >> $GITHUB_OUTPUT
+          fi
+      - name: Update CloudMetric with Failed Workflow Runs
+        run: |
+          aws cloudwatch put-metric-data \
+            --metric-name FailedWorkflowRuns \
+            --namespace GitHubWorkflow \
+            --value ${{ steps.get_failed_workflow_runs.outputs.FAILED_WORKFLOW_RUNS }} \
+            --dimensions Repository=${{ matrix.repository }} \
+            --region eu-west-2

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -21,7 +21,4 @@ jobs:
       - name: Setup GitHub API
         id: get_failed_workflow_runs
         run: |
-          echo "::set-output name=failed_workflow_runs::$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ matrix.repository }}/actions/runs?status=completed&conclusion=failure)"
-      - name: Print Failed Workflow Runs
-        run: |
-          echo "${{ steps.get_failed_workflow_runs.outputs.failed_workflow_runs }}"
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ matrix.repository }}/actions/runs?status=completed&conclusion=failure

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -1,0 +1,27 @@
+name: GitHub Workflow Monitoring
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  push:
+    branches:
+      - **
+
+jobs:
+  get_workflow_runs:
+    name: Get Failed Workflow Runs
+    strategy:
+      matrix:
+        repository:
+          - 'dso-infra-azure-ad'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup GitHub API
+        id: get_failed_workflow_runs
+        run: |
+          echo "::set-output name=failed_workflow_runs::$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ matrix.repository }}/actions/runs?status=completed&conclusion=failure)"
+      - name: Print Failed Workflow Runs
+        run: |
+          echo "${{ steps.get_failed_workflow_runs.outputs.failed_workflow_runs }}"

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -21,4 +21,5 @@ jobs:
       - name: Setup GitHub API
         id: get_failed_workflow_runs
         run: |
-          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&conclusion=failure
+          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>=$(date -d '1 day ago' '+%Y-%m-%d')
+

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -21,5 +21,6 @@ jobs:
       - name: Setup GitHub API
         id: get_failed_workflow_runs
         run: |
-          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>=$(date -d '1 day ago' '+%Y-%m-%d')
+          DATE=$(date -d '1 day ago' '+%Y-%m-%d')   
+          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>=$DATE
 

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Setup GitHub API
         id: get_failed_workflow_runs
         run: |
-          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/${{ matrix.repository }}/actions/runs?status=completed&conclusion=failure
+          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&conclusion=failure

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -22,5 +22,5 @@ jobs:
         id: get_failed_workflow_runs
         run: |
           DATE=$(date -d '1 day ago' '+%Y-%m-%d')   
-          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>=$DATE
+          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" 'https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&created=>='"$DATE"
 

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Setup GitHub API
         id: get_failed_workflow_runs
         run: |
-          curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&conclusion=failure
+          curl -s -H "Authorization: Bearer ${{ secrets.DSO_GITHUB_PAT }}" https://api.github.com/repos/ministryofjustice/${{ matrix.repository }}/actions/runs?event=schedule&status=completed&conclusion=failure


### PR DESCRIPTION
- use bare API call to get all scheduled workflows, this functionality was seemingly removed from the script action kit after v0.17
- whittle down for 'failed' workflow runs and give us a count, then ping a metric for each repo