### PR TITLE
TM-781: GitHub monitoring improvements

### DIFF
--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -20,9 +20,13 @@ on:
         type: string
         default: test
       interval:
-        description: 'time interval to check in seconds, default 6 hours'
+        description: 'time interval to check in seconds, default 1 hour'
         type: number
-        default: 21600
+        default: 3600
+      number:
+        description: 'number of historic intervals to check'
+        type: number
+        default: 168
       round:
         type: choice
         description: 'round the time interval checked to the nearest interval'
@@ -48,6 +52,7 @@ jobs:
       matrix: "${{ steps.strategy.outputs.matrix }}"
       repos: "${{ steps.options.outputs.repos }}"
       interval: "${{ steps.options.outputs.interval }}"
+      number: "${{ steps.options.outputs.number }}"
       round: "${{ steps.options.outputs.round }}"
       dryrun: "${{ steps.options.outputs.dryrun }}"
 
@@ -80,25 +85,26 @@ jobs:
         id: options
         run: |
           echo "Setting options event=${GITHUB_EVENT_NAME}"
-          dryrun=false
-          round=false
-          interval=21600
-          repos=all
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
             dryrun="${{ github.event.inputs.dryrun }}"
             round="${{ github.event.inputs.round }}"
             interval="${{ github.event.inputs.interval }}"
+            number="${{ github.event.inputs.number }}"
             repos="${{ github.event.inputs.repos }}"
           elif [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
-            interval=3600
+            dryrun=false
             round=true
+            interval=3600
+            number=168 # 7 days as some pipelines only run weekly
+            repos=all
           else
             echo "Unsupported event ${GITHUB_EVENT_NAME}"
             exit 1
           fi
-          echo "dryrun=${dryrun} interval=${interval} round=${round} repos=${repos}"
+          echo "dryrun=${dryrun} interval=${interval} number=${number} round=${round} repos=${repos}"
           echo "dryrun=${dryrun}" >> $GITHUB_OUTPUT
           echo "interval=${interval}" >> $GITHUB_OUTPUT
+          echo "number=${number}" >> $GITHUB_OUTPUT
           echo "round=${round}" >> $GITHUB_OUTPUT
           echo "repos=${repos}" >> $GITHUB_OUTPUT
 
@@ -137,10 +143,11 @@ jobs:
           dryrun: ${{ needs.check-strategy.outputs.dryrun }}
           round: ${{ needs.check-strategy.outputs.round }}
           interval: ${{ needs.check-strategy.outputs.interval }}
+          number: ${{ needs.check-strategy.outputs.number }}
           repos: ${{ needs.check-strategy.outputs.repos }}
           GITHUB_TOKEN: ${{ secrets.DSO_GITHUB_PAT }}
         run: |
-          options="-i $interval -c -v"
+          options="-i $interval -n $number -c -v"
           if [[ $dryrun == "true" ]]; then
             options="$options -d"
           fi

--- a/.github/workflows/github_workflow_monitoring.yml
+++ b/.github/workflows/github_workflow_monitoring.yml
@@ -42,7 +42,7 @@ on:
           - true
           - false
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0,30 * * * *"
 
 jobs:
   check-strategy:
@@ -94,8 +94,8 @@ jobs:
           elif [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
             dryrun=false
             round=true
-            interval=3600
-            number=168 # 7 days as some pipelines only run weekly
+            interval=1800
+            number=336 # 7 days as some pipelines only run weekly
             repos=all
           else
             echo "Unsupported event ${GITHUB_EVENT_NAME}"

--- a/src/github-workflow-monitoring/github-workflow-monitor.sh
+++ b/src/github-workflow-monitoring/github-workflow-monitor.sh
@@ -12,7 +12,7 @@ DRYRUN=0
 INTERVAL=
 
 usage() {
-  echo "Usage $0: [<opts>] -i <interval> [<repo1>] .. [<repoN>]
+  echo "Usage $0: [<opts>] -i <interval_in_seconds> -n <number_of_intervals> [<repo1>] .. [<repoN>]
 
 Where <opts>:
   -c                     Upload metrics to cloudwatch
@@ -67,7 +67,7 @@ main() {
   round_arg=""
   verbose_arg=""
 
-  while getopts "cdi:rv" opt; do
+  while getopts "cdi:n:rv" opt; do
       case $opt in
           c)
               CLOUDWATCH=1
@@ -78,11 +78,14 @@ main() {
           i)
               INTERVAL=${OPTARG}
               ;;
+          n)
+              NUMBER=${OPTARG}
+              ;;
           r)
               round_arg="-r"
               ;;
           v)
-              verbose_arg="-vvv"
+              verbose_arg="-vvvvv"
               ;;
           :)
               echo "Error: option ${OPTARG} requires an argument"
@@ -103,10 +106,10 @@ main() {
   fi
 
   if [[ $CLOUDWATCH == 0 ]]; then
-    python3 "$BASEDIR"/github-workflow-monitor.py --interval "$INTERVAL" $round_arg $verbose_arg "$@"
+    python3 "$BASEDIR"/github-workflow-monitor.py --interval "$INTERVAL" --number "$NUMBER" $round_arg $verbose_arg "$@"
   else
     IFS=$'\n'
-    workflow_stats=($(python3 "$BASEDIR"/github-workflow-monitor.py --interval "$INTERVAL" $round_arg $verbose_arg "$@"))
+    workflow_stats=($(python3 "$BASEDIR"/github-workflow-monitor.py --interval "$INTERVAL" --number "$NUMBER" $round_arg $verbose_arg "$@"))
     unset IFS
 
     num_stats=${#workflow_stats[@]}


### PR DESCRIPTION
Some fixes:
- use paging, some pipelines weren't being monitored because of this
- check a longer history to avoid flapping alarms, deleting failed pipelines will clear alarm
Tested manually and seems to work. 