### PR TITLE
TM-781: revert metric timestamp change

### DIFF
--- a/src/github-workflow-monitoring/github-workflow-monitor.py
+++ b/src/github-workflow-monitoring/github-workflow-monitor.py
@@ -207,7 +207,7 @@ def main():
                 sys.stderr.write(f'page {page}: {num_workflows_processed}/{total_count}{os.linesep}')
                 raise ValueError(f'API did not return all workflow page={page} processed={num_workflows_processed}/{total_count}')
 
-    csv_timestamp = end_timestamp - datetime.timedelta(seconds=1)
+    csv_timestamp = end_timestamp
     print_workflow_summary_csv(workflow_summary, csv_timestamp.strftime("%Y-%m-%dT%TZ"))
 
 


### PR DESCRIPTION
Revert a test to the timestamp used in github metrics - it was better as it was.