### PR TITLE
Tm/tm 795/onr poc

### DIFF
--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -96,8 +96,10 @@ jobs:
             exit 1
           }
 
-# NOTE: Important settings in here are --document-name and --parameters
+# NOTE: Important settings in here are --document-name and --parameters, see also use of exection_timeout below.
 
 # --parameters must be in JSON format, values must be in an array, even for single values, for Windows paths use double back slashes, enclose the entire JSON in single quotes
 
-# In this example --parameters '{"workingDirectory":["C:\\Temp"],"executionTimeout":["${{ inputs.execution_timeout }}"]}' supplis an exection_timeout value to the ssm document as well as being used in the script so that if the ssm document being called is a long running one, it won't check for success until it should have already completed.
+# Because of the JSON format requirements it's a lot easier to reference another ssm document and call it but only supplying the parameters. Otherwise,if you were to use the 'command' parameter above and try to correcly escape quotes on a huge powershell script it'll be a challenge. Much better to follow the approach below: 
+
+# --parameters '{"workingDirectory":["C:\\Temp"],"executionTimeout":["${{ inputs.execution_timeout }}"]}' supplis an exection_timeout value to the ssm document as well as being used in the script so that if the ssm document being called is a long running one, it won't check for success until it should have already completed.

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -56,24 +56,13 @@ jobs:
           $instanceId = "${{ inputs.instance_id }}"
           Write-Host "Testing connection to EC2 instance $instanceId"
 
-          # Create parameters object with properly escaped commands
-          $params = @{
-            commands = @(
-              'Get-ComputerInfo'
-            )
-          }
-
-          # Convert to JSON string with proper escaping
-          $jsonString = ConvertTo-Json $params -Depth 10 -Compress
-          Write-Host "Parameters JSON: $jsonString"
-
-          # Execute SSM command
+          # Execute SSM command with correct parameter format
           $ssmCommand = aws ssm send-command `
             --instance-ids "$instanceId" `
             --document-name "AWS-RunPowerShellScript" `
-            --parameters "@{`"commands`"=$($params.commands | ConvertTo-Json)}" `
-            --output text `
-            --query "Command.CommandId"
+            --parameters commands=["Get-ComputerInfo"] `
+            --query 'Command.CommandId' `
+            --output text
 
           if (-not $ssmCommand) {
             Write-Error "Failed to get command ID"

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -60,15 +60,25 @@ jobs:
             'Write-Host "Connection successful"',
             'Get-ComputerInfo | Out-String'
           )
-          $parameters = @{ commands = $commands } | ConvertTo-Json
 
-          $commandId = (aws ssm send-command `
-            --instance-ids $instanceId `
-            --document-name "AWS-RunPowerShellScript" `
-            --parameters $parameters `
-            --comment "Test connection to $instanceId" `
+          $sendCommandInput = @{
+            InstanceIds = @($instanceId)
+            DocumentName = 'AWS-RunPowerShellScript'
+            Parameters = @{
+              commands = $commands
+            }
+            Comment = "Test connection to $instanceId"
+          }
+
+          $jsonInput = $sendCommandInput | ConvertTo-Json -Compress
+
+          $jsonFile = Join-Path $env:RUNNER_TEMP 'send-command-input.json'
+          Set-Content -Path $jsonFile -Value $jsonInput -Encoding utf8
+
+          $commandId = aws ssm send-command `
+            --cli-input-json file://$jsonFile `
             --query "Command.CommandId" `
-            --output text).Trim()
+            --output text
 
           Write-Host "Command sent with Command ID: $commandId"
 
@@ -82,7 +92,6 @@ jobs:
             --output json | ConvertFrom-Json
 
           if ($invocation.Status -eq 'Success') {
-            Write-Host "Connection successful"
             Write-Host $invocation.StandardOutputContent
           } else {
             Write-Host "Command failed with status: $($invocation.Status)"

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -56,28 +56,32 @@ jobs:
           $instanceId = "${{ inputs.instance_id }}"
           Write-Host "Testing connection to EC2 instance $instanceId"
 
-          # Define the command with proper escaping
-          $commandJson = @{
+          # Create parameters object with properly escaped commands
+          $params = @{
             commands = @(
-              "Write-Host 'Connection successful'",
-              "Get-ComputerInfo"
+              'Write-Output "Connection successful"',
+              'Get-ComputerInfo'
             )
-          } | ConvertTo-Json -Compress
+          }
 
-          Write-Host "Command JSON: $commandJson"
+          # Convert to JSON string with proper escaping
+          $jsonString = ConvertTo-Json $params -Depth 10 -Compress
+          Write-Host "Parameters JSON: $jsonString"
 
-          $commandId = aws ssm send-command `
-            --instance-ids $instanceId `
+          # Execute SSM command
+          $ssmCommand = aws ssm send-command `
+            --instance-ids "$instanceId" `
             --document-name "AWS-RunPowerShellScript" `
-            --parameters $commandJson `
+            --parameters "@{`"commands`"=$($params.commands | ConvertTo-Json)}" `
             --output text `
             --query "Command.CommandId"
 
-          if (-not $commandId) {
+          if (-not $ssmCommand) {
             Write-Error "Failed to get command ID"
             exit 1
           }
 
+          $commandId = $ssmCommand.Trim()
           Write-Host "Command sent with Command ID: $commandId"
 
           # Wait for the command to complete

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -15,6 +15,10 @@ on:
           - 'oasys-national-reporting-production'
           - 'oasys-national-reporting-preproduction'
           - 'oasys-national-reporting-test'
+      execution_timeout:
+        description: 'How long should the document run for'
+        default: '3000'
+        required: false
 
 permissions:
   id-token: write
@@ -73,7 +77,7 @@ jobs:
           Write-Host "Command sent with Command ID: $commandId"
 
           # Wait for the command to complete
-          Start-Sleep -Seconds 10
+          Start-Sleep -Seconds "${{ inputs.execution_timeout }}"
 
           Write-Host "Checking command status for ID: $commandId"
 
@@ -91,3 +95,9 @@ jobs:
             Write-Host "Error: $($invocation.StandardErrorContent)"
             exit 1
           }
+
+# NOTE: Important settings in here are --document-name and --parameters
+
+# --parameters must be in JSON format, values must be in an array, even for single values, for Windows paths use double back slashes, enclose the entire JSON in single quotes
+
+# In this example --parameters '{"workingDirectory":["C:\\Temp"],"executionTimeout":["${{ inputs.execution_timeout }}"]}' supplis an exection_timeout value to the ssm document as well as being used in the script so that if the ssm document being called is a long running one, it won't check for success until it should have already completed.

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -56,34 +56,34 @@ jobs:
           $instanceId = "${{ inputs.instance_id }}"
           Write-Host "Testing connection to EC2 instance $instanceId"
 
-          $commands = @(
-            'Write-Host "Connection successful"',
-            'Get-ComputerInfo | Out-String'
-          )
+          # Define the command with proper escaping
+          $commandJson = @{
+            commands = @(
+              "Write-Host 'Connection successful'",
+              "Get-ComputerInfo"
+            )
+          } | ConvertTo-Json -Compress
 
-          $sendCommandInput = @{
-            InstanceIds = @($instanceId)
-            DocumentName = 'AWS-RunPowerShellScript'
-            Parameters = @{
-              commands = $commands
-            }
-            Comment = "Test connection to $instanceId"
-          }
-
-          $jsonInput = $sendCommandInput | ConvertTo-Json -Compress
-
-          $jsonFile = Join-Path $env:RUNNER_TEMP 'send-command-input.json'
-          Set-Content -Path $jsonFile -Value $jsonInput -Encoding utf8
+          Write-Host "Command JSON: $commandJson"
 
           $commandId = aws ssm send-command `
-            --cli-input-json file://$jsonFile `
-            --query "Command.CommandId" `
-            --output text
+            --instance-ids $instanceId `
+            --document-name "AWS-RunPowerShellScript" `
+            --parameters $commandJson `
+            --output text `
+            --query "Command.CommandId"
+
+          if (-not $commandId) {
+            Write-Error "Failed to get command ID"
+            exit 1
+          }
 
           Write-Host "Command sent with Command ID: $commandId"
 
           # Wait for the command to complete
           Start-Sleep -Seconds 10
+
+          Write-Host "Checking command status for ID: $commandId"
 
           # Get command output
           $invocation = aws ssm get-command-invocation `
@@ -92,8 +92,10 @@ jobs:
             --output json | ConvertFrom-Json
 
           if ($invocation.Status -eq 'Success') {
+            Write-Host "Command succeeded:"
             Write-Host $invocation.StandardOutputContent
           } else {
             Write-Host "Command failed with status: $($invocation.Status)"
             Write-Host "Error: $($invocation.StandardErrorContent)"
+            exit 1
           }

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -34,14 +34,20 @@ jobs:
           ref: ${{ github.ref }}
       - name: Parse Workflow Inputs
         id: parseinput
+        shell: powershell
+        env:
+          MODERNISATION_PLATFORM_ENVIRONMENT_MANAGEMENT: ${{ secrets.MODERNISATION_PLATFORM_ENVIRONMENT_MANAGEMENT }}
+          account_input: ${{ inputs.account }}
         run: |
-          account_id=${{ fromJSON(secrets.MODERNISATION_PLATFORM_ENVIRONMENT_MANAGEMENT).account_ids[ inputs.account ] }}
-          echo "account_id=${account_id}" >> "$GITHUB_OUTPUT"
+          $json = $env:MODERNISATION_PLATFORM_ENVIRONMENT_MANAGEMENT | ConvertFrom-Json
+          $accountId = $json.account_ids.$($env:account_input)
+          Write-Host "account_id=$accountId"
+          "account_id=$accountId" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Set AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: "arn:aws:iam::${{ needs.setup.outputs.account_id }}:role/modernisation-platform-oidc-cicd"
+          role-to-assume: "arn:aws:iam::${{ steps.parseinput.outputs.account_id }}:role/modernisation-platform-oidc-cicd"
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
 
       - name: Connect to Instance via AWS Systems Manager

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -59,7 +59,6 @@ jobs:
           # Create parameters object with properly escaped commands
           $params = @{
             commands = @(
-              'Write-Output "Connection successful"',
               'Get-ComputerInfo'
             )
           }

--- a/.github/workflows/windows_connection_test.yml
+++ b/.github/workflows/windows_connection_test.yml
@@ -56,10 +56,16 @@ jobs:
           $instanceId = "${{ inputs.instance_id }}"
           Write-Host "Testing connection to EC2 instance $instanceId"
 
+          $commands = @(
+            'Write-Host "Connection successful"',
+            'Get-ComputerInfo | Out-String'
+          )
+          $parameters = @{ commands = $commands } | ConvertTo-Json
+
           $commandId = (aws ssm send-command `
             --instance-ids $instanceId `
             --document-name "AWS-RunPowerShellScript" `
-            --parameters '{"commands":["Write-Host \\"Connection successful\\"","Get-ComputerInfo | Out-String"]}' `
+            --parameters $parameters `
             --comment "Test connection to $instanceId" `
             --query "Command.CommandId" `
             --output text).Trim()


### PR DESCRIPTION
- add example pipeline for calling SSM documents at windows instances
- calls the cli for ssm document execution on a windows host as well 

Comments at the bottom add a whole lot of clarity about how to use this