### PR TITLE
make ssm pipeline more resilient

### DIFF
--- a/.github/workflows/ssm_command_monitoring.yml
+++ b/.github/workflows/ssm_command_monitoring.yml
@@ -139,6 +139,12 @@ jobs:
           exitcode=0
           echo src/ssm-command-monitoring/ssm-command-monitor.sh $options
           src/ssm-command-monitoring/ssm-command-monitor.sh $options 2>output.txt || exitcode=$?
+          if [[ $exitcode -ne 0 ]]; then
+            echo "failed on first attempt with exitcode=${exitcode}; retrying"
+            # we get the odd CLI timeout, retry after a random delay
+            sleep $(( 10 + RANDOM % 50 ))
+            src/ssm-command-monitoring/ssm-command-monitor.sh $options 2>output.txt || exitcode=$?
+          fi
           failedcount=$(cat output.txt | grep "^Verbose1: " | cut -d" " -f2- | wc -l | tr -d [[:space:]])
           ignoredcount=$(cat output.txt | grep "^Verbose2: " | cut -d" " -f2- | wc -l | tr -d [[:space:]])
           echo "exitcode=${exitcode} failedcount=${failedcount} ignoredcount=${ignoredcount}"

--- a/src/ssm-command-monitoring/ssm-command-monitor.py
+++ b/src/ssm-command-monitoring/ssm-command-monitor.py
@@ -54,9 +54,6 @@ IGNORE_FAILURES_BY_TAGS = {
         { "server-type": "onr-boe" },  # doesn't support RHEL6
         { "server-type": "onr-web" },  # doesn't support RHEL6
     ],
-    "AWS-RunRemoteScript": [
-        { "application": "oasys" },  # remove after TM-935 fix
-    ],
 }
 
 IGNORE_FAILURES_BY_COMMENT = {
@@ -79,7 +76,7 @@ def run_aws_cli(cmd):
                             check=False,
                             timeout=AWSCLI_TIMEOUT_SECS)
     if result.returncode != 0:
-        # Can fail due to rate limiting. Sleep and try again
+        # Can fail due to rate limiting. Sleep and try again
         time.sleep(2)
         result = subprocess.run(cmd,
                                 capture_output=True,


### PR DESCRIPTION
We're getting the odd failure due to aws cli timeouts - add a retry.
Also remove the AWS-RunRemoteScript exclusion for oasys as the underlying issue has been fixed