### PR TITLE
Tm/tm 1278/fix permissions

### DIFF
--- a/.github/workflows/ndh_offloc_cloudplatfom_copy.yml
+++ b/.github/workflows/ndh_offloc_cloudplatfom_copy.yml
@@ -18,8 +18,8 @@ on:
         options:
           - "preprod"
           - "prod"
-
-  schedule:
+        
+  schedule:                # Only runs on prod environment 
     - cron: "20 02 * * *"  # Runs at 02:20 UTC daily
     - cron: "20 03 * * *"  # Runs at 03:20 UTC daily (to handle BST/GMT)
 
@@ -27,7 +27,8 @@ permissions:
   id-token: write
   contents: read
   
-run-name: ${{ format('NDH Offloc Copy to Cloud Platform {0}{1}', inputs.cp_environment, inputs.check_files == 'true' && ' (check files)' || '') }}
+run-name: ${{ github.event_name == 'schedule' && 'NDH Offloc Copy to Cloud Platform prod' || format('NDH Offloc Copy to Cloud Platform {0}{1}', inputs.cp_environment, inputs.check_files == 'true' && ' (check files)' || '') }}
+
 
 jobs:
   setup:
@@ -48,12 +49,23 @@ jobs:
       - name: Parse Workflow Inputs
         id: parseinput
         run: |
-            check_files="${{ github.event.inputs.check_files }}"
-            echo "check_files=${check_files}" >> $GITHUB_OUTPUT
+            # Check trigger types and set values
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              check_files="${{ github.event.inputs.check_files }}"
+              cp_environment="${{ github.event.inputs.cp_environment }}"
+              echo "Manual trigger detected - using provided inputs"
+            elif [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+              check_files="false"
+              cp_environment="prod"
+              echo "Scheduled trigger detected - using production environment and set check_files to false "
+            else
+              echo "Unsupported event ${GITHUB_EVENT_NAME}"
+              exit 1
+            fi
 
-            cp_environment="${{ github.event.inputs.cp_environment }}"
+            echo "check_files=${check_files}" >> $GITHUB_OUTPUT
             echo "cp_environment=${cp_environment}" >> $GITHUB_OUTPUT
-            
+
             # Generate date and file variables
             TODAY=$(date +"%d%m%Y")
             SOURCE_OFFLOC_FILE_DATE=$(date -d "yesterday" +"%d%m%Y")

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -57,7 +57,7 @@ jobs:
             
             # Generate date and file variables
             TODAY=$(date +"%d%m%Y")
-            SOURCE_OFFLOC_FILE_DATE=$(date -d "$TODAY -1 day" +"%d%m%Y")
+            SOURCE_OFFLOC_FILE_DATE=$(date -d "yesterday" +"%d%m%Y")
             FILE_NAME="C_NOMIS_OFFENDER_${SOURCE_OFFLOC_FILE_DATE}_01.dat"
             CURRENT_TIME=$(date)
             

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -6,24 +6,29 @@ on:
     inputs:
       check_files:
         type: choice
-        description: Check files mode (shows what files exist without transferring)
-        default: "true" # Default to true for testing
+        description: Check files mode (show what files exist in each bucket without transferring)
+        default: "false" # Change to true to enable check files mode
         options:
           - "true"
           - "false"
+      cp_environment:
+        type: choice
+        description: Cloud Platform environment to copy files to
+        default: "prod"
+        options:
+          - "preprod"
+          - "prod"
 
 #  schedule:
-    # Add this later
-    # requirements - check if file exists at 01:00
-    # check again at - 07:00
-    # check again at - 09:00
-    # Need to check if file is actually correct date FIRST!
+    # Check if file exists in the source bucket at 02:20 UTC
+    #  - cron: "20 02 * * *"  # Runs at 02:20 UTC daily
+    #  - cron: "20 03 * * *"  # Runs at 03:20 UTC daily (to handle BST/GMT)
 
 permissions:
   id-token: write
   contents: read
   
-run-name: "NDH Offloc Copy to Cloud Platform (${{ inputs.check_files == 'true' && ' check files)' || ')' }}"
+run-name: "NDH Offloc Copy to Cloud Platform ${{ inputs.cp_environment }} (${{ inputs.check_files == 'true' && ' check files)' || ')' }}"
 
 jobs:
   setup:
@@ -31,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         check_files: "${{ steps.parseinput.outputs.check_files }}"
+        cp_environment: "${{ steps.parseinput.outputs.cp_environment }}"
         today: "${{ steps.parseinput.outputs.today }}"
         file_name: "${{ steps.parseinput.outputs.file_name }}"
         current_time: "${{ steps.parseinput.outputs.current_time }}"
@@ -45,19 +51,25 @@ jobs:
         run: |
             check_files="${{ github.event.inputs.check_files }}"
             echo "check_files=${check_files}" >> $GITHUB_OUTPUT
+
+            cp_environment="${{ github.event.inputs.cp_environment }}"
+            echo "cp_environment=${cp_environment}" >> $GITHUB_OUTPUT
             
             # Generate date and file variables
             TODAY=$(date +"%d%m%Y")
-            FILE_NAME="C_NOMIS_OFFENDER_${TODAY}_01.dat"
+            SOURCE_OFFLOC_FILE_DATE=$(date -d "$TODAY -1 day" +"%d%m%Y")
+            FILE_NAME="C_NOMIS_OFFENDER_${SOURCE_OFFLOC_FILE_DATE}_01.dat"
             CURRENT_TIME=$(date)
             
             echo "today=${TODAY}" >> $GITHUB_OUTPUT
+            echo "source_offloc_file_date=${SOURCE_OFFLOC_FILE_DATE}" >> $GITHUB_OUTPUT
             echo "file_name=${FILE_NAME}" >> $GITHUB_OUTPUT
             echo "current_time=${CURRENT_TIME}" >> $GITHUB_OUTPUT
             
             echo "Setup complete:"
             echo "- Check files mode: ${check_files}"
             echo "- Today: ${TODAY}"
+            echo "- Source Offloc file date: ${SOURCE_OFFLOC_FILE_DATE}"
             echo "- File name: ${FILE_NAME}"
             echo "- Current time: ${CURRENT_TIME}"
             
@@ -94,38 +106,20 @@ jobs:
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-source"
           aws-region: eu-west-2
 
-      - name: Check Source Bucket
+      - name: Check Source File
         id: check_source
         env:
             SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
             FILE_NAME: ${{ needs.setup.outputs.file_name }}
             TODAY: ${{ needs.setup.outputs.today }}
             CURRENT_TIME: ${{ needs.setup.outputs.current_time }}
-            CHECK_FILES: ${{ needs.setup.outputs.check_files }}
         run: |
-            LOCAL_FILE="/tmp/${FILE_NAME}"
+            echo "Checking source bucket for: ${FILE_NAME}"
             
-            echo "🔍 Checking source bucket for: ${FILE_NAME}"
-            
-            # Check if today's file exists in source bucket
+            # Check if the target file exists in source bucket
             if aws s3 ls "s3://${SOURCE_BUCKET}/${FILE_NAME}" >/dev/null 2>&1; then
               echo "File ${FILE_NAME} found in source bucket"
               echo "source_file_exists=true" >> $GITHUB_OUTPUT
-              
-              if [[ "${CHECK_FILES}" == "false" ]]; then
-                # Download the file
-                echo "Downloading ${FILE_NAME}..."
-                aws s3 cp "s3://${SOURCE_BUCKET}/${FILE_NAME}" "${LOCAL_FILE}"
-                
-                if [[ $? -eq 0 ]]; then
-                  echo "File downloaded successfully to ${LOCAL_FILE}"
-                  echo "file_downloaded=true" >> $GITHUB_ENV
-                  echo "local_file=${LOCAL_FILE}" >> $GITHUB_ENV
-                else
-                  echo "Failed to download file"
-                  exit 1
-                fi
-              fi
             else
               echo "File for ${TODAY} is not yet available at ${CURRENT_TIME}"
               echo "source_file_exists=false" >> $GITHUB_OUTPUT
@@ -142,97 +136,142 @@ jobs:
                 MOST_RECENT=$(echo "${RECENT_FILES}" | head -1 | awk '{print $4}')
                 echo "Most recent file: ${MOST_RECENT}"
               else
-                echo "No C_NOMIS_OFFENDER files found in source bucket"
-              fi
-              
-              if [[ "${CHECK_FILES}" == "false" ]]; then
-                exit 0
+                echo "C_NOMIS_OFFENDER files not found in source bucket"
               fi
             fi
-  
+
+      - name: Download File
+        id: download_file
+        if: needs.setup.outputs.check_files == 'false' && steps.check_source.outputs.source_file_exists == 'true'
+        env:
+            SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
+            FILE_NAME: ${{ needs.setup.outputs.file_name }}
+        run: |
+            LOCAL_FILE="/tmp/${FILE_NAME}"
+            
+            echo "Downloading ${FILE_NAME}..."
+            aws s3 cp "s3://${SOURCE_BUCKET}/${FILE_NAME}" "${LOCAL_FILE}"
+            
+            if [[ $? -eq 0 ]]; then
+              echo "File downloaded successfully to ${LOCAL_FILE}"
+              echo "file_downloaded=true" >> $GITHUB_OUTPUT
+              echo "local_file=${LOCAL_FILE}" >> $GITHUB_OUTPUT
+            else
+              echo "Failed to download file"
+              exit 1
+            fi
+
+      - name: Prepare File for Upload
+        id: prepare_file
+        if: needs.setup.outputs.check_files == 'false' && steps.download_file.outputs.file_downloaded == 'true'
+        run: |
+            LOCAL_FILE="${{ steps.download_file.outputs.local_file }}"
+            TODAY_YYYYMMDD=$(date +"%Y%m%d")
+            ZIP_FILE="/tmp/${TODAY_YYYYMMDD}.zip"
+            
+            echo "Creating zip file: ${ZIP_FILE}"
+            zip -j "${ZIP_FILE}" "${LOCAL_FILE}"
+            
+            if [[ $? -eq 0 ]]; then
+              echo "File zipped successfully to ${ZIP_FILE}"
+              echo "zip_file=${ZIP_FILE}" >> $GITHUB_OUTPUT
+              echo "zip_filename=${TODAY_YYYYMMDD}.zip" >> $GITHUB_OUTPUT
+              
+              # Clean up original file
+              rm -f "${LOCAL_FILE}"
+              echo "Original .dat file deleted"
+            else
+              echo "Failed to zip file"
+              exit 1
+            fi
+
       - name: Configure AWS Credentials for Destination
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
-          role-to-assume: ${{ secrets.OFFLOC_TRANSFER_GHA_ROLE_ARN_PREPROD }}
+          role-to-assume: ${{ needs.setup.outputs.cp_environment == 'preprod' && secrets.OFFLOC_TRANSFER_GHA_ROLE_ARN_PREPROD || secrets.OFFLOC_TRANSFER_GHA_ROLE_ARN_PROD }}
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-dest"
           aws-region: eu-west-2
 
       - name: Check Destination Bucket
         id: check_dest
         env:
-          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }}
-          FILE_NAME: ${{ needs.setup.outputs.file_name }}
+          DEST_BUCKET: ${{ needs.setup.outputs.cp_environment == 'preprod' && secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD || secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PROD }}
           TODAY: ${{ needs.setup.outputs.today }}
           CURRENT_TIME: ${{ needs.setup.outputs.current_time }}
           CHECK_FILES: ${{ needs.setup.outputs.check_files }}
         run: |
-          echo "🔍 Checking destination bucket for: ${FILE_NAME}"
+          # Use zip filename from previous step, or calculate if not available (for check_files mode)
+          if [[ "${{ steps.prepare_file.outputs.zip_filename }}" != "" ]]; then
+            ZIP_FILENAME="${{ steps.prepare_file.outputs.zip_filename }}"
+          else
+            TODAY_YYYYMMDD=$(date +"%Y%m%d")
+            ZIP_FILENAME="${TODAY_YYYYMMDD}.zip"
+          fi
           
-          # Check if file already exists in destination bucket
-          if aws s3 ls "s3://${DEST_BUCKET}/${FILE_NAME}" >/dev/null 2>&1; then
-            echo "File ${FILE_NAME} found in destination bucket"
+          echo "Checking destination bucket for: ${ZIP_FILENAME}"
+          
+          # Check if zip file already exists in destination bucket
+          if aws s3 ls "s3://${DEST_BUCKET}/${ZIP_FILENAME}" >/dev/null 2>&1; then
+            echo "File ${ZIP_FILENAME} found in destination bucket"
             echo "dest_file_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "File ${FILE_NAME} not found in destination bucket"
+            echo "File ${ZIP_FILENAME} not found in destination bucket"
             echo "dest_file_exists=false" >> $GITHUB_OUTPUT
             
-            # Find the most recent file in destination bucket
-            echo "Looking for most recent file in destination bucket..."
-            RECENT_FILES=$(aws s3 ls "s3://${DEST_BUCKET}/" --recursive | grep "C_NOMIS_OFFENDER_.*_01\.dat" | sort -k1,2 -r | head -5)
+            # Find the most recent zip files in destination bucket
+            echo "Looking for most recent zip files in destination bucket..."
+            RECENT_FILES=$(aws s3 ls "s3://${DEST_BUCKET}/" --recursive | grep ".*\.zip$" | sort -k1,2 -r | head -5)
             
             if [[ -n "${RECENT_FILES}" ]]; then
-              echo "Most recent files found:"
+              echo "Most recent zip files found:"
               echo "${RECENT_FILES}"
               
               # Extract the most recent filename
               MOST_RECENT=$(echo "${RECENT_FILES}" | head -1 | awk '{print $4}')
-              echo "Most recent file: ${MOST_RECENT}"
+              echo "Most recent zip file: ${MOST_RECENT}"
             else
-              echo "No C_NOMIS_OFFENDER files found in destination bucket"
+              echo "No zip files found in destination bucket"
             fi
           fi
 
       - name: Process File Transfer
         if: needs.setup.outputs.check_files == 'false' && steps.check_source.outputs.source_file_exists == 'true'
         env:
-          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }}
-          FILE_NAME: ${{ needs.setup.outputs.file_name }}
+          DEST_BUCKET: ${{ needs.setup.outputs.cp_environment == 'preprod' && secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD || secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PROD }}
           TODAY: ${{ needs.setup.outputs.today }}
           CURRENT_TIME: ${{ needs.setup.outputs.current_time }}
         run: |
-          LOCAL_FILE="${{ env.local_file }}"
+          ZIP_FILE="${{ steps.prepare_file.outputs.zip_file }}"
+          ZIP_FILENAME="${{ steps.prepare_file.outputs.zip_filename }}"
           
           if [[ "${{ steps.check_dest.outputs.dest_file_exists }}" == "true" ]]; then
             echo "File for ${TODAY} already available at ${CURRENT_TIME}"
-            
-            # Delete the local file since it's already uploaded
-            echo "Deleting local file..."
-            rm -f "${LOCAL_FILE}"
-            echo "Local file deleted"
+            echo "Deleting zip file..."
+            rm -f "${ZIP_FILE}"  # Use full path
+            echo "Zip file deleted"
           else
-            echo "Uploading ${FILE_NAME} to destination bucket..."
-            aws s3 cp "${LOCAL_FILE}" "s3://${DEST_BUCKET}/${FILE_NAME}"
+            echo "Uploading ${ZIP_FILENAME} to destination bucket..."
+            aws s3 cp "${ZIP_FILE}" "s3://${DEST_BUCKET}/${ZIP_FILENAME}"  # Use full path for source, filename for destination
             
             if [[ $? -eq 0 ]]; then
-              echo "File for ${TODAY} uploaded, local file deleted at ${CURRENT_TIME}"
-              
-              # Delete the local file after successful upload
-              rm -f "${LOCAL_FILE}"
-              echo "Local file deleted"
+              echo "File ${ZIP_FILENAME} uploaded, local file deleted at ${CURRENT_TIME}"
+              rm -f "${ZIP_FILE}"  # Use full path
+              echo "Zip file deleted"
             else
               echo "Failed to upload file"
-              # Delete the local file if upload fails
-              rm -f "${LOCAL_FILE}"
-              echo "Local file deleted after failed upload"
+              rm -f "${ZIP_FILE}"  # Use full path
+              echo "Zip file deleted after failed upload"
               exit 1
             fi
           fi
 
       - name: Summary
         run: |
-          echo "📊 Summary:"
-          echo "- Mode: ${{ needs.setup.outputs.check_files == 'true' && 'Check Files' || 'Transfer' }}"
-          echo "- Target file: ${{ needs.setup.outputs.file_name }}"
+          echo "Summary:"
+          echo "- Mode: ${{ needs.setup.outputs.check_files == 'true' && 'Check Files' || 'Upload to Cloud Platform' }}"
+          echo "- Environment: ${{ needs.setup.outputs.cp_environment }}"
+          echo "- Source file: ${{ needs.setup.outputs.file_name }}"
+          echo "- Target zip file: ${{ steps.prepare_file.outputs.zip_filename || 'Not created' }}"
           echo "- Source file exists: ${{ steps.check_source.outputs.source_file_exists || 'unknown' }}"
           echo "- Destination file exists: ${{ steps.check_dest.outputs.dest_file_exists || 'unknown' }}"
           echo "- Current time: ${{ needs.setup.outputs.current_time }}"

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -97,7 +97,7 @@ jobs:
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-dest"
           aws-region: eu-west-2
 
-      - name: Test S3 Source Bucket Access
+      - name: Test S3 Destination Bucket Access
         env:
           # SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
           DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }} # Preprod only at the moment
@@ -107,9 +107,10 @@ jobs:
           if [[ "${DRY_RUN}" == "true" ]]; then
             echo "[DRY RUN] Would test access to destination bucket: ${DEST_BUCKET}"
           else
+            echo "Test file created at $(date)" > /tmp/test_file.txt
             echo "Testing destination bucket access..."
-            aws s3 ls "s3://${DEST_BUCKET}/"
-            echo "S3 destination bucket access confirmed"
+            aws s3 cp /tmp/test_file.txt "s3://${DEST_BUCKET}/"
+            # echo "S3 destination bucket access confirmed"
           fi
 
       # - name: Check and Copy File

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -211,7 +211,7 @@ jobs:
           
           # Check if zip file already exists in destination bucket
           if aws s3 ls "s3://${DEST_BUCKET}/${ZIP_FILENAME}" >/dev/null 2>&1; then
-            echo "File ${ZIP_FILENAME} found in destination bucket"
+            echo "File ${ZIP_FILENAME} already exists in destination bucket"
             echo "dest_file_exists=true" >> $GITHUB_OUTPUT
           else
             echo "File ${ZIP_FILENAME} not found in destination bucket"

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -84,7 +84,7 @@ jobs:
             echo "[DRY RUN] Would test access to destination bucket: ${DEST_BUCKET}"
           else
             echo "Testing source bucket access..."
-            aws s3 ls "s3://${SOURCE_BUCKET}/" | head 1
+            aws s3 ls "s3://${SOURCE_BUCKET}/"
             echo "Testing destination bucket access..."
             aws s3 ls "s3://${DEST_BUCKET}/"
             echo "S3 bucket access confirmed"

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -246,7 +246,7 @@ jobs:
           if [[ "${{ steps.check_dest.outputs.dest_file_exists }}" == "true" ]]; then
             echo "File for ${TODAY} already available at ${CURRENT_TIME}"
             echo "Deleting zip file..."
-            rm -f "${ZIP_FILE}"  # Use full path
+            rm -f "${ZIP_FILE}"
             echo "Zip file deleted"
           else
             echo "Uploading ${ZIP_FILENAME} to destination bucket..."
@@ -254,11 +254,11 @@ jobs:
             
             if [[ $? -eq 0 ]]; then
               echo "File ${ZIP_FILENAME} uploaded, local file deleted at ${CURRENT_TIME}"
-              rm -f "${ZIP_FILE}"  # Use full path
+              rm -f "${ZIP_FILE}"
               echo "Zip file deleted"
             else
               echo "Failed to upload file"
-              rm -f "${ZIP_FILE}"  # Use full path
+              rm -f "${ZIP_FILE}"
               echo "Zip file deleted after failed upload"
               exit 1
             fi

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -4,9 +4,9 @@ name: NDH Offloc Copy to Cloud Platform
 on:
   workflow_dispatch:
     inputs:
-      dry_run:
+      check_files:
         type: choice
-        description: Run in dry run mode (leave as false unless testing)
+        description: Check files mode (shows what files exist without transferring)
         default: "true" # Default to true for testing
         options:
           - "true"
@@ -22,15 +22,18 @@ on:
 permissions:
   id-token: write
   contents: read
-
-run-name: "NDH Offloc Copy to Cloud Platform (${{ inputs.dry_run == 'true' && ' dry run)' || ')' }}"
+  
+run-name: "NDH Offloc Copy to Cloud Platform (${{ inputs.check_files == 'true' && ' check files)' || ')' }}"
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
     outputs:
-      dry_run: "${{ steps.parseinput.outputs.dry_run }}"
+        check_files: "${{ steps.parseinput.outputs.check_files }}"
+        today: "${{ steps.parseinput.outputs.today }}"
+        file_name: "${{ steps.parseinput.outputs.file_name }}"
+        current_time: "${{ steps.parseinput.outputs.current_time }}"
     steps:
       - name: Checkout Repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b  # v4.1.4
@@ -40,18 +43,37 @@ jobs:
       - name: Parse Workflow Inputs
         id: parseinput
         run: |
-          dry_run="${{ github.event.inputs.dry_run }}"
-          echo "::set-output name=dry_run::${dry_run}"
-          if [[ "${dry_run}" == "true" ]]; then
-            echo "Running in dry run mode."
-          else
-            echo "Running in normal mode."
-          fi      
+            check_files="${{ github.event.inputs.check_files }}"
+            echo "check_files=${check_files}" >> $GITHUB_OUTPUT
+            
+            # Generate date and file variables
+            TODAY=$(date +"%d%m%Y")
+            FILE_NAME="C_NOMIS_OFFENDER_${TODAY}_01.dat"
+            CURRENT_TIME=$(date)
+            
+            echo "today=${TODAY}" >> $GITHUB_OUTPUT
+            echo "file_name=${FILE_NAME}" >> $GITHUB_OUTPUT
+            echo "current_time=${CURRENT_TIME}" >> $GITHUB_OUTPUT
+            
+            echo "Setup complete:"
+            echo "- Check files mode: ${check_files}"
+            echo "- Today: ${TODAY}"
+            echo "- File name: ${FILE_NAME}"
+            echo "- Current time: ${CURRENT_TIME}"
+            
+            if [[ "${check_files}" == "true" ]]; then
+              echo "Running in check files mode."
+            else
+              echo "Running in transfer mode."
+            fi      
  
   copytocloudplatform:
     name: Copy to Cloud Platform
     needs: setup
     runs-on: ubuntu-latest
+    outputs:
+      source_file_exists: ${{ steps.check_source.outputs.source_file_exists }}
+      dest_file_exists: ${{ steps.check_dest.outputs.dest_file_exists }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b
@@ -65,124 +87,152 @@ jobs:
           echo "account_id=${account_id}"
           echo "account_id=${account_id}" >> $GITHUB_OUTPUT
 
-      - name: Configure AWS Credentials
+      - name: Configure AWS Credentials for Source
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
           role-to-assume: "arn:aws:iam::${{ steps.account_id.outputs.account_id }}:role/modernisation-platform-oidc-cicd"
-          role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}"
+          role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-source"
           aws-region: eu-west-2
 
-      - name: Test S3 Source Bucket Access
+      - name: Check Source Bucket
+        id: check_source
         env:
-          SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
-          # DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }} # Preprod only at the moment
-          DRY_RUN: ${{ needs.setup.outputs.dry_run }}
+            SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
+            FILE_NAME: ${{ needs.setup.outputs.file_name }}
+            TODAY: ${{ needs.setup.outputs.today }}
+            CURRENT_TIME: ${{ needs.setup.outputs.current_time }}
+            CHECK_FILES: ${{ needs.setup.outputs.check_files }}
         run: |
-          echo "Testing access to S3 buckets..."
-          if [[ "${DRY_RUN}" == "true" ]]; then
-            echo "[DRY RUN] Would test access to source bucket: ${SOURCE_BUCKET}"
-          else
-            echo "Testing source bucket access..."
-            aws s3 ls "s3://${SOURCE_BUCKET}/"
-            echo "S3 source bucket access confirmed"
-          fi
-
-      - name: Configure AWS Destination Credentials
-        env:
-          DEST_BUCKET_ACCOUNT_ID: ${{ secrets.CLOUD_PLATFORM_ACCOUNT_ID}}
+            LOCAL_FILE="/tmp/${FILE_NAME}"
+            
+            echo "🔍 Checking source bucket for: ${FILE_NAME}"
+            
+            # Check if today's file exists in source bucket
+            if aws s3 ls "s3://${SOURCE_BUCKET}/${FILE_NAME}" >/dev/null 2>&1; then
+              echo "File ${FILE_NAME} found in source bucket"
+              echo "source_file_exists=true" >> $GITHUB_OUTPUT
+              
+              if [[ "${CHECK_FILES}" == "false" ]]; then
+                # Download the file
+                echo "Downloading ${FILE_NAME}..."
+                aws s3 cp "s3://${SOURCE_BUCKET}/${FILE_NAME}" "${LOCAL_FILE}"
+                
+                if [[ $? -eq 0 ]]; then
+                  echo "File downloaded successfully to ${LOCAL_FILE}"
+                  echo "file_downloaded=true" >> $GITHUB_ENV
+                  echo "local_file=${LOCAL_FILE}" >> $GITHUB_ENV
+                else
+                  echo "Failed to download file"
+                  exit 1
+                fi
+              fi
+            else
+              echo "File for ${TODAY} is not yet available at ${CURRENT_TIME}"
+              echo "source_file_exists=false" >> $GITHUB_OUTPUT
+              
+              # Find the most recent file in source bucket
+              echo "Looking for most recent file in source bucket..."
+              RECENT_FILES=$(aws s3 ls "s3://${SOURCE_BUCKET}/" --recursive | grep "C_NOMIS_OFFENDER_.*_01\.dat" | sort -k1,2 -r | head -5)
+              
+              if [[ -n "${RECENT_FILES}" ]]; then
+                echo "Most recent files found:"
+                echo "${RECENT_FILES}"
+                
+                # Extract the most recent filename
+                MOST_RECENT=$(echo "${RECENT_FILES}" | head -1 | awk '{print $4}')
+                echo "Most recent file: ${MOST_RECENT}"
+              else
+                echo "No C_NOMIS_OFFENDER files found in source bucket"
+              fi
+              
+              if [[ "${CHECK_FILES}" == "false" ]]; then
+                exit 0
+              fi
+            fi
+  
+      - name: Configure AWS Credentials for Destination
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
-          # role-to-assume: "arn:aws:iam::${DEST_BUCKET_ACCOUNT_ID}:role/offloc-transfer-gha-role-preprod"
           role-to-assume: ${{ secrets.OFFLOC_TRANSFER_GHA_ROLE_ARN_PREPROD }}
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-dest"
           aws-region: eu-west-2
 
-      - name: Test S3 Destination Bucket Access
+      - name: Check Destination Bucket
+        id: check_dest
         env:
-          # SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
-          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }} # Preprod only at the moment
-          DRY_RUN: ${{ needs.setup.outputs.dry_run }}
+          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }}
+          FILE_NAME: ${{ needs.setup.outputs.file_name }}
+          TODAY: ${{ needs.setup.outputs.today }}
+          CURRENT_TIME: ${{ needs.setup.outputs.current_time }}
+          CHECK_FILES: ${{ needs.setup.outputs.check_files }}
         run: |
-          echo "Testing access to S3 buckets..."
-          if [[ "${DRY_RUN}" == "true" ]]; then
-            echo "[DRY RUN] Would test access to destination bucket: ${DEST_BUCKET}"
+          echo "🔍 Checking destination bucket for: ${FILE_NAME}"
+          
+          # Check if file already exists in destination bucket
+          if aws s3 ls "s3://${DEST_BUCKET}/${FILE_NAME}" >/dev/null 2>&1; then
+            echo "File ${FILE_NAME} found in destination bucket"
+            echo "dest_file_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "Test file created at $(date)" > /tmp/test_file.txt
-            echo "Testing destination bucket access..."
-            aws s3 cp /tmp/test_file.txt "s3://${DEST_BUCKET}/"
-            # echo "S3 destination bucket access confirmed"
+            echo "File ${FILE_NAME} not found in destination bucket"
+            echo "dest_file_exists=false" >> $GITHUB_OUTPUT
+            
+            # Find the most recent file in destination bucket
+            echo "Looking for most recent file in destination bucket..."
+            RECENT_FILES=$(aws s3 ls "s3://${DEST_BUCKET}/" --recursive | grep "C_NOMIS_OFFENDER_.*_01\.dat" | sort -k1,2 -r | head -5)
+            
+            if [[ -n "${RECENT_FILES}" ]]; then
+              echo "Most recent files found:"
+              echo "${RECENT_FILES}"
+              
+              # Extract the most recent filename
+              MOST_RECENT=$(echo "${RECENT_FILES}" | head -1 | awk '{print $4}')
+              echo "Most recent file: ${MOST_RECENT}"
+            else
+              echo "No C_NOMIS_OFFENDER files found in destination bucket"
+            fi
           fi
 
-      # - name: Check and Copy File
-      #   env:
-      #     SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
-      #     DEST_BUCKET: ${{ secrets.secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }}
-      #     DRY_RUN: ${{ needs.setup.outputs.dry_run }}
-      #   run: |
-      #     # Calculate cutoff time (23:00 local time of previous day)
-      #     cutoff_time=$(TZ=Europe/London date -d "yesterday 23:00" -u +"%Y-%m-%dT%H:%M:%SZ")
-      #     echo "Cutoff time (UTC): ${cutoff_time}"
-      #     cutoff_epoch=$(date -d "${cutoff_time}" +%s)
+      - name: Process File Transfer
+        if: needs.setup.outputs.check_files == 'false' && steps.check_source.outputs.source_file_exists == 'true'
+        env:
+          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }}
+          FILE_NAME: ${{ needs.setup.outputs.file_name }}
+          TODAY: ${{ needs.setup.outputs.today }}
+          CURRENT_TIME: ${{ needs.setup.outputs.current_time }}
+        run: |
+          LOCAL_FILE="${{ env.local_file }}"
           
-      #     # Find the most recent file in source bucket
-      #     echo "Searching for files in source bucket..."
-      #     if [[ "${DRY_RUN}" == "true" ]]; then
-      #       echo "[DRY RUN] Would search for files in s3://${SOURCE_BUCKET}/"
-      #       echo "[DRY RUN] Would check if file timestamp is newer than ${cutoff_time}"
-      #       echo "[DRY RUN] Would copy qualifying file to s3://${DEST_BUCKET}/"
-      #       exit 0
-      #     fi
-          
-      #     # Get list of files with timestamps
-      #     files_info=$(aws s3 ls "s3://${SOURCE_BUCKET}/" --recursive | sort -k1,2)
-          
-      #     if [[ -z "${files_info}" ]]; then
-      #       echo "No files found in source bucket"
-      #       exit 1
-      #     fi
-          
-      #     echo "Files found:"
-      #     echo "${files_info}"
-          
-      #     # Find the most recent file that meets our criteria
-      #     latest_file=""
-      #     latest_timestamp=""
-          
-      #     while IFS= read -r line; do
-      #       if [[ -n "${line}" ]]; then
-      #         # Parse S3 ls output: date time size filename
-      #         file_date=$(echo "${line}" | awk '{print $1}')
-      #         file_time=$(echo "${line}" | awk '{print $2}')
-      #         file_name=$(echo "${line}" | awk '{print $4}')
+          if [[ "${{ steps.check_dest.outputs.dest_file_exists }}" == "true" ]]; then
+            echo "File for ${TODAY} already available at ${CURRENT_TIME}"
+            
+            # Delete the local file since it's already uploaded
+            echo "Deleting local file..."
+            rm -f "${LOCAL_FILE}"
+            echo "Local file deleted"
+          else
+            echo "Uploading ${FILE_NAME} to destination bucket..."
+            aws s3 cp "${LOCAL_FILE}" "s3://${DEST_BUCKET}/${FILE_NAME}"
+            
+            if [[ $? -eq 0 ]]; then
+              echo "File for ${TODAY} uploaded, local file deleted at ${CURRENT_TIME}"
               
-      #         # Convert to UTC timestamp for comparison
-      #         file_datetime="${file_date}T${file_time}"
-      #         file_epoch=$(date -d "${file_datetime}" +%s 2>/dev/null || echo "0")
-              
-      #         if [[ ${file_epoch} -gt ${cutoff_epoch} ]]; then
-      #           if [[ -z "${latest_timestamp}" ]] || [[ ${file_epoch} -gt ${latest_timestamp} ]]; then
-      #             latest_file="${file_name}"
-      #             latest_timestamp=${file_epoch}
-      #             echo "Found qualifying file: ${file_name} (${file_datetime})"
-      #           fi
-      #         fi
-      #       fi
-      #     done <<< "${files_info}"
-          
-      #     if [[ -z "${latest_file}" ]]; then
-      #       echo "No files found newer than ${cutoff_time}"
-      #       exit 0
-      #     fi
-          
-      #     echo "Latest qualifying file: ${latest_file}"
-      #     echo "Copying to destination bucket..."
-          
-      #     # Copy the file
-      #     aws s3 cp "s3://${SOURCE_BUCKET}/${latest_file}" "s3://${DEST_BUCKET}/${latest_file}"
-          
-      #     if [[ $? -eq 0 ]]; then
-      #       echo "Successfully copied ${latest_file} to destination bucket"
-      #     else
-      #       echo "Failed to copy file"
-      #       exit 1
-      #     fi
+              # Delete the local file after successful upload
+              rm -f "${LOCAL_FILE}"
+              echo "Local file deleted"
+            else
+              echo "Failed to upload file"
+              # Delete the local file if upload fails
+              rm -f "${LOCAL_FILE}"
+              echo "Local file deleted after failed upload"
+              exit 1
+            fi
+          fi
+
+      - name: Summary
+        run: |
+          echo "📊 Summary:"
+          echo "- Mode: ${{ needs.setup.outputs.check_files == 'true' && 'Check Files' || 'Transfer' }}"
+          echo "- Target file: ${{ needs.setup.outputs.file_name }}"
+          echo "- Source file exists: ${{ steps.check_source.outputs.source_file_exists || 'unknown' }}"
+          echo "- Destination file exists: ${{ steps.check_dest.outputs.dest_file_exists || 'unknown' }}"
+          echo "- Current time: ${{ needs.setup.outputs.current_time }}"

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -84,9 +84,9 @@ jobs:
             echo "[DRY RUN] Would test access to destination bucket: ${DEST_BUCKET}"
           else
             echo "Testing source bucket access..."
-            aws s3 ls "s3://${SOURCE_BUCKET}/" --max-items 1
+            aws s3 ls "s3://${SOURCE_BUCKET}/" | head 1
             echo "Testing destination bucket access..."
-            aws s3 ls "s3://${DEST_BUCKET}/" --max-items 1
+            aws s3 ls "s3://${DEST_BUCKET}/"
             echo "S3 bucket access confirmed"
           fi
 

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -19,16 +19,15 @@ on:
           - "preprod"
           - "prod"
 
-#  schedule:
-    # Check if file exists in the source bucket at 02:20 UTC
-    #  - cron: "20 02 * * *"  # Runs at 02:20 UTC daily
-    #  - cron: "20 03 * * *"  # Runs at 03:20 UTC daily (to handle BST/GMT)
+  schedule:
+    - cron: "20 02 * * *"  # Runs at 02:20 UTC daily
+    - cron: "20 03 * * *"  # Runs at 03:20 UTC daily (to handle BST/GMT)
 
 permissions:
   id-token: write
   contents: read
   
-run-name: "NDH Offloc Copy to Cloud Platform ${{ inputs.cp_environment }} (${{ inputs.check_files == 'true' && ' check files)' || ')' }}"
+run-name: "NDH Offloc Copy to Cloud Platform ${{ inputs.cp_environment }} (${{ inputs.check_files == 'true' && 'check files)' || 'copy files)' }}"
 
 jobs:
   setup:
@@ -70,8 +69,8 @@ jobs:
             echo "- Check files mode: ${check_files}"
             echo "- Today: ${TODAY}"
             echo "- Source Offloc file date: ${SOURCE_OFFLOC_FILE_DATE}"
-            echo "- File name: ${FILE_NAME}"
-            echo "- Current time: ${CURRENT_TIME}"
+            echo "- Target Offloc file name: ${FILE_NAME}"
+            echo "- Pipeline run time: ${CURRENT_TIME}"
             
             if [[ "${check_files}" == "true" ]]; then
               echo "Running in check files mode."
@@ -268,10 +267,10 @@ jobs:
       - name: Summary
         run: |
           echo "Summary:"
-          echo "- Mode: ${{ needs.setup.outputs.check_files == 'true' && 'Check Files' || 'Upload to Cloud Platform' }}"
+          echo "- Mode: ${{ needs.setup.outputs.check_files == 'true' && 'Check Files' || 'Copy to Cloud Platform' }}"
           echo "- Environment: ${{ needs.setup.outputs.cp_environment }}"
           echo "- Source file: ${{ needs.setup.outputs.file_name }}"
           echo "- Target zip file: ${{ steps.prepare_file.outputs.zip_filename || 'Not created' }}"
           echo "- Source file exists: ${{ steps.check_source.outputs.source_file_exists || 'unknown' }}"
           echo "- Destination file exists: ${{ steps.check_dest.outputs.dest_file_exists || 'unknown' }}"
-          echo "- Current time: ${{ needs.setup.outputs.current_time }}"
+          echo "- Pipeline run time: ${{ needs.setup.outputs.current_time }}"

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -27,7 +27,7 @@ permissions:
   id-token: write
   contents: read
   
-run-name: "NDH Offloc Copy to Cloud Platform ${{ inputs.cp_environment }} (${{ inputs.check_files == 'true' && 'check files)' || 'copy files)' }}"
+run-name: ${{ format('NDH Offloc Copy to Cloud Platform {0}{1}', inputs.cp_environment, inputs.check_files == 'true' && ' (check files)' || '') }}
 
 jobs:
   setup:

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -92,7 +92,7 @@ jobs:
           DEST_BUCKET_ACCOUNT_ID: ${{ secrets.CLOUD_PLATFORM_ACCOUNT_ID}}
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
-          role-to-assume: "arn:aws:iam::${DEST_BUCKET_ACCOUNT_ID}:role/modernisation-platform-oidc-cicd"
+          role-to-assume: "arn:aws:iam::${DEST_BUCKET_ACCOUNT_ID}:role/offloc-transfer-gha-role-preprod"
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-dest"
           aws-region: eu-west-2
 

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -72,22 +72,43 @@ jobs:
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}"
           aws-region: eu-west-2
 
-      - name: Test S3 Bucket Access
+      - name: Test S3 Source Bucket Access
         env:
           SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
-          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }} # Preprod only at the moment
+          # DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }} # Preprod only at the moment
           DRY_RUN: ${{ needs.setup.outputs.dry_run }}
         run: |
           echo "Testing access to S3 buckets..."
           if [[ "${DRY_RUN}" == "true" ]]; then
             echo "[DRY RUN] Would test access to source bucket: ${SOURCE_BUCKET}"
-            echo "[DRY RUN] Would test access to destination bucket: ${DEST_BUCKET}"
           else
             echo "Testing source bucket access..."
             aws s3 ls "s3://${SOURCE_BUCKET}/"
+            echo "S3 source bucket access confirmed"
+          fi
+
+      - name: Configure AWS Destination Credentials
+        env:
+          DEST_BUCKET_ACCOUNT_ID: ${{ secrets.CLOUD_PLATFORM_ACCOUNT_ID}}
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
+        with:
+          role-to-assume: "arn:aws:iam::${DEST_BUCKET_ACCOUNT_ID}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-dest"
+          aws-region: eu-west-2
+
+      - name: Test S3 Source Bucket Access
+        env:
+          # SOURCE_BUCKET: ${{ secrets.OFFLOC_SOURCE_BUCKET }}
+          DEST_BUCKET: ${{ secrets.OFFLOC_TRANSFER_S3_BUCKET_NAME_PREPROD }} # Preprod only at the moment
+          DRY_RUN: ${{ needs.setup.outputs.dry_run }}
+        run: |
+          echo "Testing access to S3 buckets..."
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "[DRY RUN] Would test access to destination bucket: ${DEST_BUCKET}"
+          else
             echo "Testing destination bucket access..."
             aws s3 ls "s3://${DEST_BUCKET}/"
-            echo "S3 bucket access confirmed"
+            echo "S3 destination bucket access confirmed"
           fi
 
       # - name: Check and Copy File

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -19,9 +19,9 @@ on:
     # check again at - 09:00
     # Need to check if file is actually correct date FIRST!
 
-# permissions:
-#   id-token: write
-#   contents: read
+permissions:
+  id-token: write
+  contents: read
 
 run-name: "NDH Offloc Copy to Cloud Platform (${{ inputs.dry_run == 'true' && ' dry run)' || ')' }}"
 

--- a/.github/workflows/offloc_copy_to_cp.yml
+++ b/.github/workflows/offloc_copy_to_cp.yml
@@ -92,7 +92,8 @@ jobs:
           DEST_BUCKET_ACCOUNT_ID: ${{ secrets.CLOUD_PLATFORM_ACCOUNT_ID}}
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
         with:
-          role-to-assume: "arn:aws:iam::${DEST_BUCKET_ACCOUNT_ID}:role/offloc-transfer-gha-role-preprod"
+          # role-to-assume: "arn:aws:iam::${DEST_BUCKET_ACCOUNT_ID}:role/offloc-transfer-gha-role-preprod"
+          role-to-assume: ${{ secrets.OFFLOC_TRANSFER_GHA_ROLE_ARN_PREPROD }}
           role-session-name: "github-${{ github.repository_id }}-${{ github.run_id }}-dest"
           aws-region: eu-west-2
 


### PR DESCRIPTION
Working
- assumes oidc role
- pulls file from NDH offloc S3 bucket
- assumes cloud-platform role set up previously by Jon Quinn
- checks whether new file has already been uploaded to Cloud platform 
- zips and renames file as per note below
- uploads file to CP S3 bucket
- deletes downloaded file from runner as a security precaution
- deletes zip file from runner as a security precaution

Functionality
- runs at 2:20 a.m. and 3:20 a.m. to take into account GMT and the possibility that the original offloc may take time/fail
- allows 'check mode' to list files in the source and destination bucket, rather than making users look at s3 buckets manually
- allows copying file manually to preprod S3 as and when needed, more for CP testing than anything
- IMPORTANT: CP apps expect file format YYYMMDD.zip dated for the day on which the file is to be used, not the exported date. See step "Prepare File for Upload" for details.

Benefits
- Pipeline runs independently of the whole offloc file creation process, less risk of failure - request by @antonygowland 
- Pipeline output will make it pretty clear if/when the offloc upload has failed or where the issue lies if something else
- Pipeline can be easily extended to send the file to other consumers if needed
- TODO: add logging for an alarm that this part of the process has failed, create a separate ticket for this