### PR TITLE
TM-2128: planetfm-gfsl: pipeline improvements

### DIFF
--- a/.github/workflows/planetfm_gfsl_data_extract.yml
+++ b/.github/workflows/planetfm_gfsl_data_extract.yml
@@ -4,12 +4,14 @@ name: PlanetFM GFSL Data Extract
 on:
   workflow_dispatch:
   schedule:
-    # files are created on share just after 05:00 localtime
-    # schedule pipeline at 06:00 and 12:20 localtime - 2 entries to deal with BST/GMT
-    - cron: "00 5 * * *"
-    - cron: "00 6 * * *"
-    - cron: "20 11 * * *"
-    - cron: "20 12 * * *"
+    # files are created on share just after 04:00 and 12:20 localtime
+    # multiple crons to deal with BST/GMT and GitHub delays
+    - cron: "10 4 * * *"
+    - cron: "10 5 * * *"
+    - cron: "10 6 * * *"
+    - cron: "30 10 * * *"
+    - cron: "30 11 * * *"
+    - cron: "30 12 * * *"
 
 permissions:
   id-token: write
@@ -29,25 +31,6 @@ jobs:
         run: |
           account_name="hmpps-domain-services-production"
           ec2_name_tag="pd-jump2022-1"
-
-          if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
-            cron_time="${{ github.event.schedule }}"
-            is_bst=1
-            if [[ $(TZ=Europe/London date +%H) == $(date -u +%H) ]]; then
-              is_bst=0
-            fi
-            if [[ "${cron_time}" == '00 5 * * *' || "${cron_time}" == '20 11 * * *' ]]; then
-              if ((is_bst == 0)); then
-                account_name=
-                ec2_name_tag=
-              fi
-            elif [[ "${cron_time}" == '00 6 * * *' || "${cron_time}" == '20 12 * * *' ]]; then
-              if ((is_bst == 1)); then
-                account_name=
-                ec2_name_tag=
-              fi
-            fi
-          fi
           echo "account_name=${account_name} ec2_name_tag=${ec2_name_tag}"
           echo "account_name=${account_name}" >> $GITHUB_OUTPUT
           echo "ec2_name_tag=${ec2_name_tag}" >> $GITHUB_OUTPUT

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -57,15 +57,16 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
 
   foreach ($file in $files) {
     if ($file.Extension -eq ".txt") {
-      $filePath = $file.FullName
+      $filePath           = $file.FullName
+      $fileName           = $file.Name
 
-      # URL-encode the file name if necessary
-      $fileName = [System.Net.WebUtility]::UrlEncode($file.Name)
-      $uri = "$destinationUrl/$fileName"
+      $fileNameURLEncoded = [System.Net.WebUtility]::UrlEncode($fileName)
+      $uri                = "$destinationUrl/$fileNameURLEncoded"
 
       $uploadRequired = $true
       $hash           = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
-      Write-Output ("Checking " + $file.Name + ": $hash")
+
+      Write-Output "$fileName checking for existing S3 file $hash"
 
       try {
         $response   = Invoke-WebRequest -Uri $uri -Method Head
@@ -82,13 +83,13 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
       if ($uploadRequired) {
         try {
           Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream"
-          Write-Host "Uploaded $fileName successfully."
+          Write-Output "$fileName uploaded to S3"
         }
         catch {
-          Write-Error "Failed to upload $fileName. Error: $_"
+          Write-Error "$fileName Failed to upload to S3. Error: $_"
         }
       } else {
-        Write-Host "Skipping $fileName as no change"
+        Write-Output "$fileName skipping - already uploaded to S3"
       }
     }
   }
@@ -99,20 +100,23 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
   foreach ($file in $files) {
     if ($file.Extension -eq ".txt") {
       $filePath = $file.FullName
+      $fileName = $file.Name
+
+      $fileNameUtf8 = [io.path]::ChangeExtension($fileName, "utf8")
       $filePathUtf8 = [io.path]::ChangeExtension($filePath, "utf8")
 
-      # URL-encode the file name if necessary
-      $fileName = [System.Net.WebUtility]::UrlEncode([io.path]::ChangeExtension($file.Name, "utf8"))
-      $uri = "$destinationUrl/$fileName"
+      $fileNameUtf8URLEncoded = [System.Net.WebUtility]::UrlEncode($fileNameUtf8)
+      $uriUtf8 = "$destinationUrl/$fileNameUtf8URLEncoded"
 
       $content = [System.IO.File]::ReadAllText($filePath, $ansi)
       [System.IO.File]::WriteAllText($filePathUtf8, $content, $utf8)
 
       $uploadRequired = $true
       $hash           = (Get-FileHash -Path $filePathUtf8 -Algorithm SHA256).Hash
+      Write-Output "$fileNameUtf8 checking for existing S3 file $hash"
 
       try {
-        $response   = Invoke-WebRequest -Uri $uri -Method Head
+        $response   = Invoke-WebRequest -Uri $uriUtf8 -Method Head
         $remoteHash = $response.Headers["x-amz-meta-sha256"]
 
         if ($remoteHash -and $remoteHash -eq $hash) {
@@ -125,14 +129,14 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
-          Write-Host "Uploaded $fileName successfully."
+          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
+          Write-Output "$fileNameUtf8 uploaded to S3"
         }
         catch {
-          Write-Error "Failed to upload $fileName. Error: $_"
+          Write-Error "$fileNameUtf8 Failed to upload to S3. Error: $_"
         }
       } else {
-        Write-Host "Skipping $fileName as no change"
+        Write-Output "$fileNameUtf8 skipping - already uploaded to S3"
       }
       Remove-Item $filePathUtf8
     }

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -83,7 +83,7 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream"
+          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream" | Out-Null
           Write-Output "$fileName $hash uploaded to S3"
           $cache[$fileName] = $hash
         }
@@ -123,7 +123,7 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
+          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream" | Out-Null
           Write-Output "$fileNameUtf8 $hash uploaded to S3"
           $cache[$fileNameUtf8] = $hash
         }

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -51,6 +51,14 @@ Write-Output "Running PSScriptBlock under domain user"
 Invoke-Command -ComputerName localhost -Credential $credentials -Authentication CredSSP -ArgumentList $sourcePath, $destinationUrl -ScriptBlock  {
   param ($sourcePath, $destinationUrl)
 
+  $cacheFile = "$env:TEMP\planetfm-gfsl-pipeline-cache.json"
+  Write-Output "Reading cache $cacheFile"
+  if (Test-Path $cacheFile) {
+    $cache = Get-Content $cacheFile | ConvertFrom-Json
+  } else {
+    $cache = @{}
+  }
+
   # Get list of files in source directory
   Write-Output "Getting list of files from $sourcePath"
   $files = Get-ChildItem -Path $sourcePath
@@ -66,38 +74,21 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
       $uploadRequired = $true
       $hash           = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
 
-      Write-Output "$fileName checking for existing S3 file $hash"
-
-      try {
-        $response   = Invoke-WebRequest -Uri $uri -Method Head -ErrorAction Stop
-        $remoteHash = $response.Headers["x-amz-meta-sha256"]
-
-        if ($remoteHash) {
-          if ($remoteHash -eq $hash) {
-            Write-Output "$fileName skipping - already uploaded to S3"
-            $uploadRequired = $false
-          } else {
-            Write-Output "$fileName exists but changed - reuploading"
-          }
-        } else {
-          Write-Output "$fileName exists but no hash metadata - reuploading"
-        }
-      }
-      catch {
-        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 404) {
-          Write-Output "$fileName not found in S3 - uploading"
-        } else {
-          Write-Output "$fileName HEAD check failed - assuming upload needed"
+      if ($cache.ContainsKey($fileName)) {
+        if ($cache[$fileName] -eq $hash) {
+          Write-Output "$fileName $hash skipping - already uploaded"
+          $uploadRequired = $false
         }
       }
 
       if ($uploadRequired) {
         try {
-          # Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
-          Write-Output "$fileName uploaded to S3"
+          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream"
+          Write-Output "$fileName $hash uploaded to S3"
+          $cache[$fileName] = $hash
         }
         catch {
-          Write-Error "$fileName Failed to upload to S3. Error: $_"
+          Write-Error "$fileName $hash upload error: $_"
         }
       }
     }
@@ -122,41 +113,28 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
 
       $uploadRequired = $true
       $hash           = (Get-FileHash -Path $filePathUtf8 -Algorithm SHA256).Hash
-      Write-Output "$fileNameUtf8 checking for existing S3 file $hash"
 
-      try {
-        $response   = Invoke-WebRequest -Uri $uriUtf8 -Method Head
-        $remoteHash = $response.Headers["x-amz-meta-sha256"]
-
-        if ($remoteHash) {
-          if ($remoteHash -eq $hash) {
-            Write-Output "$fileNameUtf8 skipping - already uploaded to S3"
-            $uploadRequired = $false
-          } else {
-            Write-Output "$fileNameUtf8 exists but changed - reuploading"
-          }
-        } else {
-          Write-Output "$fileNameUtf8 exists but no hash metadata - reuploading"
-        }
-      }
-      catch {
-        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 404) {
-          Write-Output "$fileNameUtf8 not found in S3 - uploading"
-        } else {
-          Write-Output "$fileNameUtf8 HEAD check failed - assuming upload needed"
+      if ($cache.ContainsKey($fileNameUtf8)) {
+        if ($cache[$fileNameUtf8] -eq $hash) {
+          Write-Output "$fileNameUtf8 $hash skipping - already uploaded"
+          $uploadRequired = $false
         }
       }
 
       if ($uploadRequired) {
         try {
-          # Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
-          Write-Output "$fileNameUtf8 uploaded to S3"
+          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
+          Write-Output "$fileNameUtf8 $hash uploaded to S3"
+          $cache[$fileNameUtf8] = $hash
         }
         catch {
-          Write-Error "$fileNameUtf8 Failed to upload to S3. Error: $_"
+          Write-Error "$fileNameUtf8 $hash upload error: $_"
         }
       }
       Remove-Item $filePathUtf8
     }
   }
+  Write-Output "Writing cache $cacheFile"
+  $cache | ConvertTo-Json | Set-Content $cacheFile
+
 }

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -63,15 +63,32 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
       $fileName = [System.Net.WebUtility]::UrlEncode($file.Name)
       $uri = "$destinationUrl/$fileName"
 
+      $uploadRequired = $true
+      $hash           = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
+
       try {
-        Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream"
-        Write-Host "Uploaded $fileName successfully."
+        $response   = Invoke-WebRequest -Uri $uri -Method Head
+        $remoteHash = $response.Headers["x-amz-meta-sha256"]
+
+        if ($remoteHash -and $remoteHash -eq $hash) {
+          $uploadRequired = $false
+        }
       }
       catch {
-        Write-Error "Failed to upload $fileName. Error: $_"
+        continue
       }
-    } else {
-      Write-Output ("Ignoring " + $file.Name)
+
+      if ($uploadRequired) {
+        try {
+          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream"
+          Write-Host "Uploaded $fileName successfully."
+        }
+        catch {
+          Write-Error "Failed to upload $fileName. Error: $_"
+        }
+      } else {
+        Write-Host "Skipping $fileName as no change"
+      }
     }
   }
 
@@ -87,16 +104,36 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
       $fileName = [System.Net.WebUtility]::UrlEncode([io.path]::ChangeExtension($file.Name, "utf8"))
       $uri = "$destinationUrl/$fileName"
 
+      $content = [System.IO.File]::ReadAllText($filePath, $ansi)
+      [System.IO.File]::WriteAllText($filePathUtf8, $content, $utf8)
+
+      $uploadRequired = $true
+      $hash           = (Get-FileHash -Path $filePathUtf8 -Algorithm SHA256).Hash
+
       try {
-        $content = [System.IO.File]::ReadAllText($filePath, $ansi)
-        [System.IO.File]::WriteAllText($filePathUtf8, $content, $utf8)
-        Invoke-RestMethod -Uri $uri -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
-        Write-Host "Uploaded $fileName successfully."
-        Remove-Item $filePathUtf8
+        $response   = Invoke-WebRequest -Uri $uri -Method Head
+        $remoteHash = $response.Headers["x-amz-meta-sha256"]
+
+        if ($remoteHash -and $remoteHash -eq $hash) {
+          $uploadRequired = $false
+        }
       }
       catch {
-        Write-Error "Failed to upload $fileName. Error: $_"
+        continue
       }
+
+      if ($uploadRequired) {
+        try {
+          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
+          Write-Host "Uploaded $fileName successfully."
+        }
+        catch {
+          Write-Error "Failed to upload $fileName. Error: $_"
+        }
+      } else {
+        Write-Host "Skipping $fileName as no change"
+      }
+      Remove-Item $filePathUtf8
     }
   }
 }

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -65,6 +65,7 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
 
       $uploadRequired = $true
       $hash           = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
+      Write-Output ("Checking " + $file.Name + ": $hash")
 
       try {
         $response   = Invoke-WebRequest -Uri $uri -Method Head

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -69,7 +69,7 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
       Write-Output "$fileName checking for existing S3 file $hash"
 
       try {
-        $response   = Invoke-WebRequest -Uri $uri -Method Head
+        $response   = Invoke-WebRequest -Uri $uri -Method Head -ErrorAction Stop
         $remoteHash = $response.Headers["x-amz-meta-sha256"]
 
         if ($remoteHash -and $remoteHash -eq $hash) {
@@ -77,12 +77,11 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
         }
       }
       catch {
-        continue
       }
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream"
+          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
           Write-Output "$fileName uploaded to S3"
         }
         catch {
@@ -124,12 +123,11 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
         }
       }
       catch {
-        continue
       }
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream"
+          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
           Write-Output "$fileNameUtf8 uploaded to S3"
         }
         catch {

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -54,7 +54,11 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
   $cacheFile = "$env:TEMP\planetfm-gfsl-pipeline-cache.json"
   Write-Output "Reading cache $cacheFile"
   if (Test-Path $cacheFile) {
-    $cache = Get-Content $cacheFile | ConvertFrom-Json
+    $rawCache = Get-Content $cacheFile -Raw | ConvertFrom-Json
+    $cache = @{}
+    foreach ($prop in $rawCache.PSObject.Properties) {
+      $cache[$prop.Name] = $prop.Value
+    }
   } else {
     $cache = @{}
   }

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -84,6 +84,10 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
           $uploadRequired = $false
         }
       }
+      if ($file.LastWriteTime -gt (Get-Date).AddSeconds(-60)) {
+        Write-Output "$fileName $hash skipping - last updated < 60s"
+        $uploadRequired = $false
+      }
 
       if ($uploadRequired) {
         try {
@@ -123,6 +127,10 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
           Write-Output "$fileNameUtf8 $hash skipping - already uploaded"
           $uploadRequired = $false
         }
+      }
+      if ($file.LastWriteTime -gt (Get-Date).AddSeconds(-60)) {
+        Write-Output "$fileNameUtf8 $hash skipping - last updated < 60s"
+        $uploadRequired = $false
       }
 
       if ($uploadRequired) {

--- a/src/planetfm/Add-GFSLDataExtract.ps1
+++ b/src/planetfm/Add-GFSLDataExtract.ps1
@@ -72,23 +72,33 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
         $response   = Invoke-WebRequest -Uri $uri -Method Head -ErrorAction Stop
         $remoteHash = $response.Headers["x-amz-meta-sha256"]
 
-        if ($remoteHash -and $remoteHash -eq $hash) {
-          $uploadRequired = $false
+        if ($remoteHash) {
+          if ($remoteHash -eq $hash) {
+            Write-Output "$fileName skipping - already uploaded to S3"
+            $uploadRequired = $false
+          } else {
+            Write-Output "$fileName exists but changed - reuploading"
+          }
+        } else {
+          Write-Output "$fileName exists but no hash metadata - reuploading"
         }
       }
       catch {
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 404) {
+          Write-Output "$fileName not found in S3 - uploading"
+        } else {
+          Write-Output "$fileName HEAD check failed - assuming upload needed"
+        }
       }
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
+          # Invoke-RestMethod -Uri $uri -Method Put -InFile $filePath -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
           Write-Output "$fileName uploaded to S3"
         }
         catch {
           Write-Error "$fileName Failed to upload to S3. Error: $_"
         }
-      } else {
-        Write-Output "$fileName skipping - already uploaded to S3"
       }
     }
   }
@@ -118,23 +128,33 @@ Invoke-Command -ComputerName localhost -Credential $credentials -Authentication 
         $response   = Invoke-WebRequest -Uri $uriUtf8 -Method Head
         $remoteHash = $response.Headers["x-amz-meta-sha256"]
 
-        if ($remoteHash -and $remoteHash -eq $hash) {
-          $uploadRequired = $false
+        if ($remoteHash) {
+          if ($remoteHash -eq $hash) {
+            Write-Output "$fileNameUtf8 skipping - already uploaded to S3"
+            $uploadRequired = $false
+          } else {
+            Write-Output "$fileNameUtf8 exists but changed - reuploading"
+          }
+        } else {
+          Write-Output "$fileNameUtf8 exists but no hash metadata - reuploading"
         }
       }
       catch {
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode -eq 404) {
+          Write-Output "$fileNameUtf8 not found in S3 - uploading"
+        } else {
+          Write-Output "$fileNameUtf8 HEAD check failed - assuming upload needed"
+        }
       }
 
       if ($uploadRequired) {
         try {
-          Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
+          # Invoke-RestMethod -Uri $uriUtf8 -Method Put -InFile $filePathUtf8 -ContentType "application/octet-stream" -Headers @{ "x-amz-meta-sha256" = $hash }
           Write-Output "$fileNameUtf8 uploaded to S3"
         }
         catch {
           Write-Error "$fileNameUtf8 Failed to upload to S3. Error: $_"
         }
-      } else {
-        Write-Output "$fileNameUtf8 skipping - already uploaded to S3"
       }
       Remove-Item $filePathUtf8
     }


### PR DESCRIPTION
Add additional cron times because github pipelines are running late, and the reports are available earlier than they were.
Updated pipeline to be more robust:
- don't upload files that have already been uploaded
- don't upload files with a recent last modified timestamp, i.e. might still be being written to.